### PR TITLE
اطلاعات میرور دانشگاه اصفهان

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | [repo-portal.ito.gov.ir](https://repo-portal.ito.gov.ir/repo/) | نگهداری شده توسط سازمان فناوری اطلاعات ایران | مخازن YUM/DNF برای CentOS، Fedora، Rocky، مخازن Python، npm، Yarn و … |
 | [jamko.ir](https://jamko.ir/) | ارائه مستندات و نمونه‌های کانفیگ برای استفاده آسان‌تر | مخازن Maven، Gradle، Android SDK، APT، RPM، NuGet، Yarn، Composer، pip |
 | [runflare.com/mirrors](https://runflare.com/mirrors/) | دارای راهنمای ساده و آپدیت خودکار روزانه | Composer/Packagist، PyPI، npm، Node.js، رجیستری Docker |
+| [repo.iut.ac.ir](https://repo.iut.ac.ir/) | میرور جامع دانشگاه صنعتی اصفهان با پوشش گسترده توزیع‌های لینوکسی و پروژه‌های متن‌باز | توزیع‌های Debian، Ubuntu، Mint، Arch Linux، Manjaro، Raspbian، Alpine، Rocky Linux، Fedora، OpenSUSE، OpenBSD و مخازن CTAN |
 
 ---
 

--- a/mirrors_list.yaml
+++ b/mirrors_list.yaml
@@ -61,3 +61,20 @@ mirrors:
       - Arch Linux
       - PyPI
       - Homebrew
+
+  - name: IUT (Isfahan University of Technology)
+    url: https://repo.iut.ac.ir/
+    description: Local mirror by Isfahan University of Technology offering broad Linux and open-source package coverage.
+    packages:
+      - Alpine
+      - Rocky Linux
+      - Debian
+      - Ubuntu
+      - Mint
+      - Arch Linux
+      - Manjaro
+      - Raspbian
+      - Fedora
+      - OpenSuse
+      - OpenBSD
+      - CTAN


### PR DESCRIPTION
سلام و ممنون بابت این ریپوی فوق‌العاده واقعاً وجود همچین لیستی برای میرورهای ایرانی خیلی ضروری بود.
میرور دانشگاه اصفهان رو هم به لیست اضافه کردم که از توزیع‌های زیر پشتیبانی می‌کنه:

```ini
- Alpine
- Rocky Linux
- Debian
- Ubuntu
- Mint
- Arch Linux
- Manjaro
- Raspbian
- Fedora
- OpenSuse
- OpenBSD
```