### PR TITLE
Remove duplicate reference to iranrepo.ir (Fixes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@
 
 | میرور (لینک) | توضیحات | پکیج‌های پوشش داده‌شده |
 |--------------|----------|--------------------------|
-| [iranrepo.ir](https://iranrepo.ir/repo) | پروژه ملی مخازن متن‌باز ایران با پشتیبانی رسمی | بسته‌های Conda، پایتون (Python wheels)، برخی مخازن توزیع‌ها مانند Linux Mint |
 | [mirror.shatel.ir](https://mirror.shatel.ir/) | میرور رسمی اوبونتو | مخازن اوبونتو، دبیان، کالی و فایل‌های نصب‌کننده |
 | [mirrors.kubarcloud.com](https://mirrors.kubarcloud.com/linux/) | میرور داخلی کوبار با پشتیبانی | سورس کرنل لینوکس و آرشیوهای متن‌باز متنوع |
 | [repo-portal.ito.gov.ir](https://repo-portal.ito.gov.ir/repo/) | نگهداری شده توسط سازمان فناوری اطلاعات ایران | مخازن YUM/DNF برای CentOS، Fedora، Rocky، مخازن Python، npm، Yarn و … |

--- a/mirrors_list.yaml
+++ b/mirrors_list.yaml
@@ -1,13 +1,4 @@
 mirrors:
-  - name: Iranrepo
-    url: https://iranrepo.ir/repo
-    description: A local mirror providing various Linux package repositories inside Iran.
-    packages:
-      - Debian
-      - Ubuntu
-      - Arch Linux
-      - PyPI
-
   - name: KubarCloud
     url: https://mirrors.kubarcloud.com/
     description: Public software mirror hosted by Kubar Cloud, with wide package coverage.


### PR DESCRIPTION
Removed the duplicate mirror link from both mirrors_list.yaml and README.md. Only the official mirror is kept to keep things clean and consistent.

Fixes #6