### PR TITLE
Add Arvancloud Linux Repository Mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | [hub.hamdocker.ir](https://hub.hamdocker.ir) | داکر ریجستری | Docker Registry |
 | [repo.iut.ac.ir](https://repo.iut.ac.ir/) | میرور جامع دانشگاه صنعتی اصفهان با پوشش گسترده توزیع‌های لینوکسی و پروژه‌های متن‌باز | توزیع‌های Debian، Ubuntu، Mint، Arch Linux، Manjaro، Raspbian، Alpine، Rocky Linux، Fedora، OpenSUSE، OpenBSD و مخازن CTAN |
 | [maven.myket.ir](https://maven.myket.ir/) | میرور جامعی از مخازن کتابخانه های اندرویدی شامل mavenCentral - googleMaven - Jitpack | Android sdk - android maven central - android jitpack - android googleMaven |
-
+| [arvancloud.ir/dev/linux-repository](https://www.arvancloud.ir/en/dev/linux-repository) | میرور داخلی و پرسرعت از ریپازیتوری‌های محبوب‌ترین توزیع‌های گنو/لینوکس بر روی سرورهای ابر آروان| Debian, Ubuntu, CentOS, Alpine, Arch Linux, OpenSUSE, Manjaro |
 
 ---
 

--- a/mirrors_list.yaml
+++ b/mirrors_list.yaml
@@ -81,4 +81,14 @@ mirrors:
       - Maven (jitpack)
       - Maven (maven central)
 
-  
+  - name: Arvancloud
+    url: https://www.arvancloud.ir/en/dev/linux-repository
+    description: Most up-to-date versions of GNU/Linux repositories on Arvancloud mirror servers
+    packages:
+      - Debian
+      - Ubuntu
+      - CentOS
+      - Alpine
+      - Arch Linux
+      - OpenSUSE
+      - Manjaro


### PR DESCRIPTION
Adding arvancloud mirror which supports the main repositories of Ubuntu, Debian, CentOS, ArchLinux, Linux Alpine, Manjaro and OpenSUSE distros.

