### PR TITLE
feat: add r1cloud docker registry

### DIFF
--- a/mirrors_list.yaml
+++ b/mirrors_list.yaml
@@ -108,7 +108,7 @@ mirrors:
       - Docker Registry
 
   - name: Arvancloud
-    url: https://docker.arvancloud.ir
+    url: https://www.arvancloud.ir/fa/dev/docker
     description: Docker registry mirror in iran hosted by Arvancloud
     packages:
       - Docker Registry


### PR DESCRIPTION
This PR Adds ArvanCloud's Docker Registry to the list of mirrors