### PR TITLE
R language's official mirror in Iran

### DIFF
--- a/mirrors_list.yaml
+++ b/mirrors_list.yaml
@@ -145,4 +145,9 @@ mirrors:
       - Maven (jitpack)
       - Maven (maven central)
       - Others (Can be added)
-
+      
+  - name: Ferdowsi University of Mashhad
+    url: https://cran.um.ac.ir/
+    description: The Comprehensive R Archive Network (CRAN)
+    packages:
+      - R


### PR DESCRIPTION
For reference, please visit [the official list of CRAN Mirrors](https://cran.r-project.org/mirrors.html#:~:text=Iran,University%20of%20Mashhad).