### PR TITLE
feat: add PubYar Dart Pub mirror

### DIFF
--- a/mirrors_list.yaml
+++ b/mirrors_list.yaml
@@ -344,3 +344,10 @@ mirrors:
     description: Iranian proxy for Maven Central.
     packages:
       - Maven Central
+
+  - name: PubYar
+    url: https://pub.pubyar.ir
+    description: Smart read-only Dart Pub and Flutter package mirror/CDN for Iranian developers.
+    packages:
+      - Dart Pub
+      - Flutter packages


### PR DESCRIPTION
Adds PubYar as a smart read-only Dart Pub and Flutter package mirror/CDN for Iranian developers.